### PR TITLE
New Redirect Buttons

### DIFF
--- a/scripts/HypernexAPI.js
+++ b/scripts/HypernexAPI.js
@@ -17,6 +17,25 @@ const API_CONFIGURATION = {
     "DiscourseUrl": "https://forum.hypernex.dev/"
 }
 
+export const GITHUB_DOWNLOADS = {
+    "Hypernex.Unity": {
+        "Repo": "TigersUniverse/Hypernex.Unity",
+        "Files": ["Hypernex_win-x64.zip"]
+    },
+    "Hypernex.Launcher": {
+        "Repo": "TigersUniverse/Hypernex.Launcher",
+        "Files": ["Hypernex.Launcher.exe"]
+    },
+    "Hypernex.Networking.Server": {
+        "Repo": "TigersUniverse/Hypernex.Networking",
+        "Files": ["Hypernex.Networking.Server.zip"]
+    },
+    "Hypernex.CCK": {
+        "Repo": "TigersUniverse/Hypernex.CCK",
+        "InstallGuide": "https://docs.hypernex.dev/docs/nexademy/intro/cck"
+    }
+}
+
 /*
  * DO NOT EDIT ANYTHING PAST HERE UNLESS YOU KNOW WHAT YOU ARE DOING!
  *

--- a/scripts/githubtools.js
+++ b/scripts/githubtools.js
@@ -1,0 +1,45 @@
+export async function GetVersion(repoPath){
+    const gitUrl = "https://github.com/" + repoPath + "/releases/latest"
+    const finalUrl = await getFinalRedirect(gitUrl);
+    if (finalUrl) {
+        const parts = finalUrl.split('/');
+        const tag = parts[parts.length - 1];
+        return tag;
+    }
+    return "unknown";
+}
+
+export function GetLatestBuildUrl(repoPath, fileName){
+    return "https://github.com/" + repoPath + "/releases/latest/download/" + fileName
+}
+
+async function getFinalRedirect(url) {
+    if (!url || !url.trim()) return url;
+    let maxRedirects = 8;
+    let currentUrl = url;
+    try {
+        while (maxRedirects-- > 0) {
+            const response = await fetch(currentUrl, {
+                method: 'HEAD',
+                redirect: 'manual'
+            });
+            if (response.status === 200) {
+                return currentUrl;
+            }
+            if ([301, 302, 303, 307, 308].includes(response.status)) {
+                const location = response.headers.get('Location');
+                if (!location) return currentUrl;
+                try {
+                    currentUrl = new URL(location, currentUrl).toString();
+                } catch {
+                    return currentUrl;
+                }
+            } else {
+                return currentUrl;
+            }
+        }
+    } catch (error) {
+        return currentUrl;
+    }
+    return currentUrl;
+}

--- a/scripts/githubtools.js
+++ b/scripts/githubtools.js
@@ -1,6 +1,5 @@
 export async function GetVersion(repoPath){
-    const gitUrl = "https://github.com/" + repoPath + "/releases/latest"
-    const finalUrl = await getFinalRedirect(gitUrl);
+    const finalUrl = await getFinalRedirect(repoPath);
     if (finalUrl) {
         const parts = finalUrl.split('/');
         const tag = parts[parts.length - 1];
@@ -10,36 +9,19 @@ export async function GetVersion(repoPath){
 }
 
 export function GetLatestBuildUrl(repoPath, fileName){
+    if(repoPath === undefined || fileName === undefined)
+        return undefined
     return "https://github.com/" + repoPath + "/releases/latest/download/" + fileName
 }
 
-async function getFinalRedirect(url) {
-    if (!url || !url.trim()) return url;
-    let maxRedirects = 8;
-    let currentUrl = url;
-    try {
-        while (maxRedirects-- > 0) {
-            const response = await fetch(currentUrl, {
-                method: 'HEAD',
-                redirect: 'manual'
-            });
-            if (response.status === 200) {
-                return currentUrl;
-            }
-            if ([301, 302, 303, 307, 308].includes(response.status)) {
-                const location = response.headers.get('Location');
-                if (!location) return currentUrl;
-                try {
-                    currentUrl = new URL(location, currentUrl).toString();
-                } catch {
-                    return currentUrl;
-                }
-            } else {
-                return currentUrl;
-            }
+async function getFinalRedirect(repoPath) {
+    const response = await fetch(`https://api.github.com/repos/${repoPath}/releases/latest`, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/vnd.github.v3+json'
         }
-    } catch (error) {
-        return currentUrl;
-    }
-    return currentUrl;
+    });
+    let json = await response.json();
+    return json.html_url;
 }
+

--- a/scripts/web/dashboard/dashboard.js
+++ b/scripts/web/dashboard/dashboard.js
@@ -240,6 +240,10 @@ function initDownloadButton(button, name, artifact, display){
    let redirUrl = currentModal["InstallGuide"]
     if(redirUrl === undefined)
         redirUrl = githubtools.GetLatestBuildUrl(currentModal["Repo"], currentModal["Files"][artifact])
+    if(redirUrl === undefined){
+        button.hidden = true
+        return;
+    }
    button.addEventListener("click", () => window.open(redirUrl, '_blank'))
 }
 
@@ -254,7 +258,7 @@ function setupDownloads(){
                 b.addEventListener("click", () => window.location = "unityhub://" + gameEngineObject.GameEngineVersion)
                 b.textContent = "Download Unity " + gameEngineObject.GameEngineVersion + " in Unity Hub"
                 initDownloadButton(document.getElementById("download-hypernex.client"), "Hypernex.Unity", 0, "Hypernex.Unity for Windows")
-                //initDownloadButton(document.getElementById("download-hypernex.client-android"), "Hypernex.Unity", 1, "Hypernex.Unity for Android")
+                initDownloadButton(document.getElementById("download-hypernex.client-android"), "Hypernex.Unity", 1, "Hypernex.Unity for Android")
                 initDownloadButton(document.getElementById("download-hypernex.cck"), "Hypernex.CCK", 0)
                 break
             case "godot":


### PR DESCRIPTION
The buttons on the dashboard for downloading have now been rewritten to redirect to our latest GitHub releases and their versions are now pulled from the latest GitHub release.

For compatibility with openupm (the CCK's package manager), a hard-coded redirect url is allocated. All of these configurations can be changed by developers in the HypernexAPI.js file.